### PR TITLE
Call font.dispose() in dispose callback, fonts need to be disposed of.

### DIFF
--- a/1.4.10-Exercise-WordCloud/core/src/com/udacity/gamedev/wordcloud/WordCloud.java
+++ b/1.4.10-Exercise-WordCloud/core/src/com/udacity/gamedev/wordcloud/WordCloud.java
@@ -55,6 +55,7 @@ public class WordCloud extends ApplicationAdapter {
     @Override
     public void dispose() {
         batch.dispose();
+        font.dispose();
     }
 
     @Override

--- a/1.4.10-Solution-WordCloud/core/src/com/udacity/gamedev/wordcloud/WordCloud.java
+++ b/1.4.10-Solution-WordCloud/core/src/com/udacity/gamedev/wordcloud/WordCloud.java
@@ -55,6 +55,7 @@ public class WordCloud extends ApplicationAdapter {
     @Override
     public void dispose() {
         batch.dispose();
+        font.dispose();
     }
 
     @Override


### PR DESCRIPTION
* fond.dispose() should be called in dispose callback.

/cc @JeremySilverTongue  