### PR TITLE
update gradle wraper from 2.2.0-alpha5 to 2.2.3

### DIFF
--- a/1.2.01-Demo-GettingStartedWithLibGDX/build.gradle
+++ b/1.2.01-Demo-GettingStartedWithLibGDX/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.2.01-Demo-GettingStartedWithLibGDX/gradle/wrapper/gradle-wrapper.properties
+++ b/1.2.01-Demo-GettingStartedWithLibGDX/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.01-Demo-DrawingPoints/build.gradle
+++ b/1.3.01-Demo-DrawingPoints/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.01-Demo-DrawingPoints/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.01-Demo-DrawingPoints/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 28 14:53:08 PDT 2016
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.02-Exercise-DrawAStarfield/build.gradle
+++ b/1.3.02-Exercise-DrawAStarfield/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.02-Exercise-DrawAStarfield/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.02-Exercise-DrawAStarfield/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.02-Solution-DrawAStarfield/build.gradle
+++ b/1.3.02-Solution-DrawAStarfield/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.02-Solution-DrawAStarfield/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.02-Solution-DrawAStarfield/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.03-Demo-DrawingLines/build.gradle
+++ b/1.3.03-Demo-DrawingLines/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.03-Demo-DrawingLines/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.03-Demo-DrawingLines/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.04-Exercise-ConnectTheDots/build.gradle
+++ b/1.3.04-Exercise-ConnectTheDots/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.04-Exercise-ConnectTheDots/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.04-Exercise-ConnectTheDots/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.04-Solution-ConnectTheDots/build.gradle
+++ b/1.3.04-Solution-ConnectTheDots/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.04-Solution-ConnectTheDots/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.04-Solution-ConnectTheDots/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.05-Exercise-DrawASpiral/build.gradle
+++ b/1.3.05-Exercise-DrawASpiral/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.05-Exercise-DrawASpiral/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.05-Exercise-DrawASpiral/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.05-Solution-DrawASpiral/build.gradle
+++ b/1.3.05-Solution-DrawASpiral/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.05-Solution-DrawASpiral/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.05-Solution-DrawASpiral/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.06-Demo-DrawingRectangles/build.gradle
+++ b/1.3.06-Demo-DrawingRectangles/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.06-Demo-DrawingRectangles/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.06-Demo-DrawingRectangles/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.07-Exercise-RectangularFlower/build.gradle
+++ b/1.3.07-Exercise-RectangularFlower/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.07-Exercise-RectangularFlower/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.07-Exercise-RectangularFlower/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.07-Solution-RectangularFlower/build.gradle
+++ b/1.3.07-Solution-RectangularFlower/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.07-Solution-RectangularFlower/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.07-Solution-RectangularFlower/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.08-Challenge-DrawTheCantorGasket/build.gradle
+++ b/1.3.08-Challenge-DrawTheCantorGasket/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.08-Challenge-DrawTheCantorGasket/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.08-Challenge-DrawTheCantorGasket/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.08-Solution-DrawTheCantorGasket/build.gradle
+++ b/1.3.08-Solution-DrawTheCantorGasket/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.08-Solution-DrawTheCantorGasket/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.08-Solution-DrawTheCantorGasket/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.09-Challenge-DrawTheDragonCurve/build.gradle
+++ b/1.3.09-Challenge-DrawTheDragonCurve/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.09-Challenge-DrawTheDragonCurve/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.09-Challenge-DrawTheDragonCurve/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.3.09-Solution-DrawTheDragonCurve/build.gradle
+++ b/1.3.09-Solution-DrawTheDragonCurve/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.3.09-Solution-DrawTheDragonCurve/gradle/wrapper/gradle-wrapper.properties
+++ b/1.3.09-Solution-DrawTheDragonCurve/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.01-Demo-CirclesAndArcs/build.gradle
+++ b/1.4.01-Demo-CirclesAndArcs/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.01-Demo-CirclesAndArcs/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.01-Demo-CirclesAndArcs/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.02-Exercise-StickFigure/build.gradle
+++ b/1.4.02-Exercise-StickFigure/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.02-Exercise-StickFigure/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.02-Exercise-StickFigure/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.02-Solution-StickFigure/build.gradle
+++ b/1.4.02-Solution-StickFigure/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.02-Solution-StickFigure/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.02-Solution-StickFigure/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.03-Demo-Cameras/build.gradle
+++ b/1.4.03-Demo-Cameras/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.03-Demo-Cameras/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.03-Demo-Cameras/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.04-Demo-SolarSystem/build.gradle
+++ b/1.4.04-Demo-SolarSystem/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.04-Demo-SolarSystem/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.04-Demo-SolarSystem/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.05-Exercise-OrthographicCamera/build.gradle
+++ b/1.4.05-Exercise-OrthographicCamera/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.05-Exercise-OrthographicCamera/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.05-Exercise-OrthographicCamera/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.05-Solution-OrthographicCamera/build.gradle
+++ b/1.4.05-Solution-OrthographicCamera/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.05-Solution-OrthographicCamera/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.05-Solution-OrthographicCamera/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.06-Demo-Viewports/build.gradle
+++ b/1.4.06-Demo-Viewports/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.06-Demo-Viewports/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.06-Demo-Viewports/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.07-Exercise-Viewports/build.gradle
+++ b/1.4.07-Exercise-Viewports/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.07-Exercise-Viewports/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.07-Exercise-Viewports/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.07-Solution-Viewports/build.gradle
+++ b/1.4.07-Solution-Viewports/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.07-Solution-Viewports/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.07-Solution-Viewports/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.08-Exercise-SmileyFace/build.gradle
+++ b/1.4.08-Exercise-SmileyFace/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.08-Exercise-SmileyFace/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.08-Exercise-SmileyFace/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.08-Solution-SmileyFace/build.gradle
+++ b/1.4.08-Solution-SmileyFace/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.08-Solution-SmileyFace/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.08-Solution-SmileyFace/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.09-Demo-Text/build.gradle
+++ b/1.4.09-Demo-Text/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.09-Demo-Text/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.09-Demo-Text/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.10-Exercise-WordCloud/build.gradle
+++ b/1.4.10-Exercise-WordCloud/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.10-Exercise-WordCloud/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.10-Exercise-WordCloud/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.10-Solution-WordCloud/build.gradle
+++ b/1.4.10-Solution-WordCloud/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.10-Solution-WordCloud/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.10-Solution-WordCloud/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.11-Challenge-CyclicOverlap/build.gradle
+++ b/1.4.11-Challenge-CyclicOverlap/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.11-Challenge-CyclicOverlap/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.11-Challenge-CyclicOverlap/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.11-Solution-CyclicOverlap/build.gradle
+++ b/1.4.11-Solution-CyclicOverlap/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.11-Solution-CyclicOverlap/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.11-Solution-CyclicOverlap/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.12-Challenge-SierpinskiTriangle/build.gradle
+++ b/1.4.12-Challenge-SierpinskiTriangle/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.12-Challenge-SierpinskiTriangle/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.12-Challenge-SierpinskiTriangle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.4.12-Solution-SierpinskiTriangle/build.gradle
+++ b/1.4.12-Solution-SierpinskiTriangle/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.4.12-Solution-SierpinskiTriangle/gradle/wrapper/gradle-wrapper.properties
+++ b/1.4.12-Solution-SierpinskiTriangle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.01-Demo-CircularMotion/build.gradle
+++ b/1.5.01-Demo-CircularMotion/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.01-Demo-CircularMotion/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.01-Demo-CircularMotion/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.02-Exercise-ReciprocatingMotion/build.gradle
+++ b/1.5.02-Exercise-ReciprocatingMotion/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.02-Exercise-ReciprocatingMotion/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.02-Exercise-ReciprocatingMotion/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.02-Solution-ReciprocatingMotion/build.gradle
+++ b/1.5.02-Solution-ReciprocatingMotion/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.02-Solution-ReciprocatingMotion/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.02-Solution-ReciprocatingMotion/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.03-Demo-GamesAndScreens/build.gradle
+++ b/1.5.03-Demo-GamesAndScreens/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.03-Demo-GamesAndScreens/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.03-Demo-GamesAndScreens/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.04-Exercise-ApplicationAdapterToGame/build.gradle
+++ b/1.5.04-Exercise-ApplicationAdapterToGame/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.04-Exercise-ApplicationAdapterToGame/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.04-Exercise-ApplicationAdapterToGame/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.04-Solution-ApplicationAdapterToGame/build.gradle
+++ b/1.5.04-Solution-ApplicationAdapterToGame/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.04-Solution-ApplicationAdapterToGame/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.04-Solution-ApplicationAdapterToGame/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.05-Exercise-FPSCounter/build.gradle
+++ b/1.5.05-Exercise-FPSCounter/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.05-Exercise-FPSCounter/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.05-Exercise-FPSCounter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.05-Solution-FPSCounter/build.gradle
+++ b/1.5.05-Solution-FPSCounter/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.05-Solution-FPSCounter/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.05-Solution-FPSCounter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.06-Exercise-FallingObjects/build.gradle
+++ b/1.5.06-Exercise-FallingObjects/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.06-Exercise-FallingObjects/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.06-Exercise-FallingObjects/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.06-Solution-FallingObjects/build.gradle
+++ b/1.5.06-Solution-FallingObjects/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.06-Solution-FallingObjects/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.06-Solution-FallingObjects/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.07-Exercise-ScreenSaver/build.gradle
+++ b/1.5.07-Exercise-ScreenSaver/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.07-Exercise-ScreenSaver/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.07-Exercise-ScreenSaver/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.5.07-Solution-ScreenSaver/build.gradle
+++ b/1.5.07-Solution-ScreenSaver/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.5.07-Solution-ScreenSaver/gradle/wrapper/gradle-wrapper.properties
+++ b/1.5.07-Solution-ScreenSaver/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.01-Demo-InputTestbed/build.gradle
+++ b/1.6.01-Demo-InputTestbed/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.01-Demo-InputTestbed/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.01-Demo-InputTestbed/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.02-Demo-InputPolling/build.gradle
+++ b/1.6.02-Demo-InputPolling/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.02-Demo-InputPolling/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.02-Demo-InputPolling/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.03-Exercise-ArrowKeyMovement/build.gradle
+++ b/1.6.03-Exercise-ArrowKeyMovement/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.03-Exercise-ArrowKeyMovement/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.03-Exercise-ArrowKeyMovement/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.03-Solution-ArrowKeyMovement/build.gradle
+++ b/1.6.03-Solution-ArrowKeyMovement/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.03-Solution-ArrowKeyMovement/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.03-Solution-ArrowKeyMovement/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.04-Demo-InputAdapter/build.gradle
+++ b/1.6.04-Demo-InputAdapter/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.04-Demo-InputAdapter/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.04-Demo-InputAdapter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.05-Exercise-ResetKey/build.gradle
+++ b/1.6.05-Exercise-ResetKey/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.05-Exercise-ResetKey/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.05-Exercise-ResetKey/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.05-Solution-ResetKey/build.gradle
+++ b/1.6.05-Solution-ResetKey/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.05-Solution-ResetKey/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.05-Solution-ResetKey/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.06-Demo-Flick/build.gradle
+++ b/1.6.06-Demo-Flick/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.06-Demo-Flick/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.06-Demo-Flick/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.07-Exercise-FollowTheFinger/build.gradle
+++ b/1.6.07-Exercise-FollowTheFinger/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.07-Exercise-FollowTheFinger/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.07-Exercise-FollowTheFinger/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.07-Solution-FollowTheFinger/build.gradle
+++ b/1.6.07-Solution-FollowTheFinger/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.07-Solution-FollowTheFinger/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.07-Solution-FollowTheFinger/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.08-Demo-AccelerometerInput/build.gradle
+++ b/1.6.08-Demo-AccelerometerInput/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.08-Demo-AccelerometerInput/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.08-Demo-AccelerometerInput/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.09-Exercise-BubbleLevel/build.gradle
+++ b/1.6.09-Exercise-BubbleLevel/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.09-Exercise-BubbleLevel/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.09-Exercise-BubbleLevel/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.09-Solution-BubbleLevel/build.gradle
+++ b/1.6.09-Solution-BubbleLevel/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.09-Solution-BubbleLevel/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.09-Solution-BubbleLevel/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.10-Exercise-AccelerometerMovement/build.gradle
+++ b/1.6.10-Exercise-AccelerometerMovement/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.10-Exercise-AccelerometerMovement/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.10-Exercise-AccelerometerMovement/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.6.10-Solution-AccelerometerMovement/build.gradle
+++ b/1.6.10-Solution-AccelerometerMovement/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.6.10-Solution-AccelerometerMovement/gradle/wrapper/gradle-wrapper.properties
+++ b/1.6.10-Solution-AccelerometerMovement/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.01-Solution-CreateTheIciclesProject/build.gradle
+++ b/1.7.01-Solution-CreateTheIciclesProject/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.8.0'
     }
 }

--- a/1.7.01-Solution-CreateTheIciclesProject/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.01-Solution-CreateTheIciclesProject/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.02-Exercise-AddStubClasses/build.gradle
+++ b/1.7.02-Exercise-AddStubClasses/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.8.0'
     }
 }

--- a/1.7.02-Exercise-AddStubClasses/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.02-Exercise-AddStubClasses/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.02-Solution-AddStubClasses/build.gradle
+++ b/1.7.02-Solution-AddStubClasses/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.02-Solution-AddStubClasses/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.02-Solution-AddStubClasses/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.03-Exercise-TheFirstIcicle/build.gradle
+++ b/1.7.03-Exercise-TheFirstIcicle/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.03-Exercise-TheFirstIcicle/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.03-Exercise-TheFirstIcicle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.03-Solution-TheFirstIcicle/build.gradle
+++ b/1.7.03-Solution-TheFirstIcicle/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.03-Solution-TheFirstIcicle/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.03-Solution-TheFirstIcicle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.04-Exercise-DrawThePlayer/build.gradle
+++ b/1.7.04-Exercise-DrawThePlayer/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.04-Exercise-DrawThePlayer/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.04-Exercise-DrawThePlayer/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.04-Solution-DrawThePlayer/build.gradle
+++ b/1.7.04-Solution-DrawThePlayer/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.04-Solution-DrawThePlayer/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.04-Solution-DrawThePlayer/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.05-Exercise-ArrowKeyControls/build.gradle
+++ b/1.7.05-Exercise-ArrowKeyControls/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.05-Exercise-ArrowKeyControls/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.05-Exercise-ArrowKeyControls/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.05-Solution-ArrowKeyControls/build.gradle
+++ b/1.7.05-Solution-ArrowKeyControls/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.05-Solution-ArrowKeyControls/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.05-Solution-ArrowKeyControls/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.06-Exercise-AccelerometerControls/build.gradle
+++ b/1.7.06-Exercise-AccelerometerControls/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.06-Exercise-AccelerometerControls/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.06-Exercise-AccelerometerControls/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.06-Solution-AccelerometerControls/build.gradle
+++ b/1.7.06-Solution-AccelerometerControls/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.06-Solution-AccelerometerControls/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.06-Solution-AccelerometerControls/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.07-Exercise-AddTheIcicles/build.gradle
+++ b/1.7.07-Exercise-AddTheIcicles/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.07-Exercise-AddTheIcicles/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.07-Exercise-AddTheIcicles/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.07-Solution-AddTheIcicles/build.gradle
+++ b/1.7.07-Solution-AddTheIcicles/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.07-Solution-AddTheIcicles/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.07-Solution-AddTheIcicles/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.08-Exercise-RemoveStaleIcicles/build.gradle
+++ b/1.7.08-Exercise-RemoveStaleIcicles/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.08-Exercise-RemoveStaleIcicles/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.08-Exercise-RemoveStaleIcicles/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.7.08-Solution-RemoveStaleIcicles/build.gradle
+++ b/1.7.08-Solution-RemoveStaleIcicles/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.7.08-Solution-RemoveStaleIcicles/gradle/wrapper/gradle-wrapper.properties
+++ b/1.7.08-Solution-RemoveStaleIcicles/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.8.01-Exercise-IcicleHeadCollisionDetection/build.gradle
+++ b/1.8.01-Exercise-IcicleHeadCollisionDetection/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.8.01-Exercise-IcicleHeadCollisionDetection/gradle/wrapper/gradle-wrapper.properties
+++ b/1.8.01-Exercise-IcicleHeadCollisionDetection/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.8.01-Solution-IcicleHeadCollisionDetection/build.gradle
+++ b/1.8.01-Solution-IcicleHeadCollisionDetection/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.8.01-Solution-IcicleHeadCollisionDetection/gradle/wrapper/gradle-wrapper.properties
+++ b/1.8.01-Solution-IcicleHeadCollisionDetection/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.8.02-Exercise-AddTheHUD/build.gradle
+++ b/1.8.02-Exercise-AddTheHUD/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.8.02-Exercise-AddTheHUD/gradle/wrapper/gradle-wrapper.properties
+++ b/1.8.02-Exercise-AddTheHUD/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.8.02-Solution-AddTheHUD/build.gradle
+++ b/1.8.02-Solution-AddTheHUD/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.8.02-Solution-AddTheHUD/gradle/wrapper/gradle-wrapper.properties
+++ b/1.8.02-Solution-AddTheHUD/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.8.03-Exercise-AddDifficultyLevels/build.gradle
+++ b/1.8.03-Exercise-AddDifficultyLevels/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.8.03-Exercise-AddDifficultyLevels/gradle/wrapper/gradle-wrapper.properties
+++ b/1.8.03-Exercise-AddDifficultyLevels/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.8.03-Solution-AddDifficultyLevels/build.gradle
+++ b/1.8.03-Solution-AddDifficultyLevels/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.8.03-Solution-AddDifficultyLevels/gradle/wrapper/gradle-wrapper.properties
+++ b/1.8.03-Solution-AddDifficultyLevels/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.8.04-Exercise-AddDifficultySelectScreen/build.gradle
+++ b/1.8.04-Exercise-AddDifficultySelectScreen/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.8.04-Exercise-AddDifficultySelectScreen/gradle/wrapper/gradle-wrapper.properties
+++ b/1.8.04-Exercise-AddDifficultySelectScreen/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/1.8.04-Solution-AddDifficultySelectScreen/build.gradle
+++ b/1.8.04-Solution-AddDifficultySelectScreen/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.robovm:robovm-gradle-plugin:1.14.0'
     }
 }

--- a/1.8.04-Solution-AddDifficultySelectScreen/gradle/wrapper/gradle-wrapper.properties
+++ b/1.8.04-Solution-AddDifficultySelectScreen/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 21 13:08:26 CEST 2013
+#Mon Jan 09 13:10:30 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
fix #27 

Updated the build.gradle and gradle-wrapper.properties files for each project to meet android studios minimum requirements. I'm working through the course now using these versions and will inform if there are any incompatibilities.