### PR TITLE
1.6.09 Bubble-level: bubble overflows the circle when force is above 9.8f

### DIFF
--- a/1.6.09-Solution-BubbleLevel/core/src/com/udacity/gamedev/bubblelevel/BubbleLevelScreen.java
+++ b/1.6.09-Solution-BubbleLevel/core/src/com/udacity/gamedev/bubblelevel/BubbleLevelScreen.java
@@ -115,8 +115,8 @@ public class BubbleLevelScreen extends ScreenAdapter {
 
         // TODO: Draw the bubble
         renderer.circle(
-                WORLD_SIZE * (.5f - .25f * yAxis / 9.8f),
-                WORLD_SIZE * (.5f + .25f * xAxis / 9.8f),
+                WORLD_SIZE * (.5f - .25f * yAxis / totalAcceleration),
+                WORLD_SIZE * (.5f + .25f * xAxis / totalAcceleration),
                 WORLD_SIZE / 50,
                 64
         );


### PR DESCRIPTION
Hi @JeremySilverTongue, Glad I could help with the android gradle version. I found a bug in the bubble level solution and figured I would share how I fixed it.

When the force on the phone is above gravity (ie. when moving the phone) the bubble can overflow the edges of the circle. I found a solution that was fairly simple so wanted to share with the class :P

Instead of dividing by gravity, I divided by the totalAcceleration.